### PR TITLE
Fix: Improve breaking change detection for file arguments

### DIFF
--- a/src/Cli/Cli.csproj
+++ b/src/Cli/Cli.csproj
@@ -7,7 +7,7 @@
 		<Nullable>enable</Nullable>
 		<PackAsTool>true</PackAsTool>
 		<PackageId>graphql-breaking-schema-change-detector</PackageId>
-		<PackageVersion>0.0.4</PackageVersion>
+		<PackageVersion>0.0.5</PackageVersion>
 		<PackageProjectUrl>https://github.com/TimHolzherr/GraphQlBreakingSchemaChangeDetector</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/TimHolzherr/GraphQlBreakingSchemaChangeDetector</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/Cli/FileCommand.cs
+++ b/src/Cli/FileCommand.cs
@@ -25,8 +25,17 @@ internal static class FileCommand
         fileCommand.SetHandler((FileInfo oldSchema, FileInfo newSchema) =>
             {
                 var schemaComparer = new SchemaComparer();
-                schemaComparer.DetectBreakingChanges(File.ReadAllText(oldSchema.FullName),
-                    File.ReadAllText(newSchema.FullName));
+                var breakingChanges = schemaComparer.DetectBreakingChanges(File.ReadAllText(oldSchema.FullName), File.ReadAllText(newSchema.FullName));
+
+                if (breakingChanges.Any())
+                {
+                    Console.WriteLine("Breaking changes detected:");
+                    foreach (var breakingChange in breakingChanges)
+                    {
+                        Console.WriteLine(breakingChange);
+                    }
+                    Environment.Exit(1);
+                }
             },
             oldSchemaOption,
             newSchemaOption);


### PR DESCRIPTION
**Issue Description:** I noticed that when using the tool with a file argument, breaking changes were not being reported correctly. Even when breaking changes were detected, no output or exit status indicated the issue, leading to a silent failure in identifying schema discrepancies.

**Modifications:**

In src/Cli/FileCommand.cs, I’ve updated the handler for the fileCommand to ensure that any detected breaking changes are reported to the console. Additionally, the application will now exit with a non-zero code if breaking changes are found, improving visibility and flow control in CI/CD pipelines or any automated environments.

**Key Changes:**

The DetectBreakingChanges method now checks for breaking changes.
If breaking changes are found, they are printed to the console.
The process exits with status code 1 to signal failure, which can be handled in external scripts or CI pipelines.
This modification ensures that users are properly informed of any breaking changes when comparing schema files and that the tool behaves predictably in automated environments.